### PR TITLE
Clean tags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,12 +23,13 @@ dependencies = [ #pandas and scikit-learn are dependencies of emodpy-hiv, so we 
 ]
 license = "MIT"
 classifiers=[
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
-		"Programming Language :: Python :: 3.14",
-        "Framework:: IDM-Tools :: models",
-        "Operating System :: OS Independent",
+    "Intended Audience :: Science/Research",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Operating System :: OS Independent",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Using non-standard tags like "Framework:: IDM-Tools :: models" in the pyproject file generates strange, unhelpful error messages when trying to upload to PyPI 